### PR TITLE
opencv_contrib "depth_registration.cpp"  "point_tmp" segmentation fault

### DIFF
--- a/modules/rgbd/src/depth_registration.cpp
+++ b/modules/rgbd/src/depth_registration.cpp
@@ -145,9 +145,10 @@ namespace rgbd
 
         // Apply the initial projection to the input depth
         Mat_<Point3f> transformedCloud;
-        {
-            Mat_<Point3f> point_tmp(outputImagePlaneSize);
-
+        {         
+            Size inputImagePlaneSize(unregisteredDepth.cols, unregisteredDepth.rows);
+            Mat_<Point3f> point_tmp(inputImagePlaneSize);
+         
             for(int j = 0; j < point_tmp.rows; ++j)
             {
                 const DepthDepth *unregisteredDepthPtr = unregisteredDepth[j];


### PR DESCRIPTION
The size of "point_tmp" should equal to that of "unregisteredDepth" to correctly access the value stored in "unregisteredDepth"

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
